### PR TITLE
implements semaphore with mutex

### DIFF
--- a/Instant-Messenger/Makefile
+++ b/Instant-Messenger/Makefile
@@ -8,10 +8,10 @@ BUILD_DIR=./build
 all: build-server build-client
 
 build-client:
-	${CC} -std=c++11 -o $(BUILD_DIR)/client.app $(SRC_DIR)/util/Socket.cpp $(SRC_DIR)/app/app_client.cpp $(SRC_DIR)/client/*.cpp
+	${CC} -std=c++11 -g -o $(BUILD_DIR)/client.app $(SRC_DIR)/util/Socket.cpp $(SRC_DIR)/app/app_client.cpp $(SRC_DIR)/client/*.cpp
 
 build-server:
-	${CC} -pthread -std=c++11 -o $(BUILD_DIR)/server.app $(SRC_DIR)/util/Socket.cpp $(SRC_DIR)/app/app_server.cpp $(SRC_DIR)/server/server.cpp \
+	${CC} -pthread -std=c++11 -g -o $(BUILD_DIR)/server.app $(SRC_DIR)/util/Socket.cpp $(SRC_DIR)/util/Semaphore.cpp $(SRC_DIR)/app/app_server.cpp $(SRC_DIR)/server/server.cpp \
 	$(SRC_DIR)/server/server_group_manager.cpp $(SRC_DIR)/util/user.cpp 
 
 run-client:

--- a/Instant-Messenger/include/util/Semaphore.hpp
+++ b/Instant-Messenger/include/util/Semaphore.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef __semaphore_h__
+#define __semaphore_h__
+
+#include <mutex>
+#include <condition_variable>
+
+using std::mutex;
+using std::condition_variable;
+
+class Semaphore {
+
+public:
+    Semaphore(int init);
+    void wait();
+    void post();
+
+private:
+    int m_value; // semaphore value
+    mutex m_mux;
+    condition_variable m_waitcond;
+};
+
+#endif

--- a/Instant-Messenger/include/util/user.hpp
+++ b/Instant-Messenger/include/util/user.hpp
@@ -5,14 +5,12 @@
 #include <ctime>
 #include <list>
 #include "exceptions.hpp"
-#include <semaphore.h>
+#include "Semaphore.hpp"
 
 using namespace std;
 using std::string;
 
 #define NUMBER_OF_SIMULTANEOUS_CONNECTIONS 2
-
-extern sem_t semaphore;
 
 namespace user {
 
@@ -22,12 +20,9 @@ class User {
         string username;
         // this list of sockets can only have two items
         int sockets[NUMBER_OF_SIMULTANEOUS_CONNECTIONS];
-        void init_semaphore();
-        void wait_semaphore();
-        void post_semaphore();
+        Semaphore semaphore;
     
     public:
-        User();
         User(string username);
         string getUsername();
         void getActiveSockets(int* activeSocketsResult);
@@ -39,6 +34,8 @@ class User {
         */
         int registerSession(int socket);
         void releaseSession(int socket);
+        void initSessionList();
+
         
 };
 }  //namespace user;

--- a/Instant-Messenger/src/util/Semaphore.cpp
+++ b/Instant-Messenger/src/util/Semaphore.cpp
@@ -1,0 +1,24 @@
+#include <mutex>
+#include <condition_variable>
+#include "../../include/util/Semaphore.hpp"
+
+
+using std::unique_lock;
+using std::mutex;
+
+Semaphore::Semaphore(int init) {
+    this->m_value = init;
+}
+
+void Semaphore::wait() {
+    unique_lock<mutex> lck(m_mux);
+    // make us wait
+    if (--m_value < 0) {
+        m_waitcond.wait(lck);
+    }
+}
+
+void Semaphore::post() {
+    unique_lock<mutex> lck(m_mux);
+    if (++m_value <= 0) m_waitcond.notify_one();
+}

--- a/Instant-Messenger/src/util/user.cpp
+++ b/Instant-Messenger/src/util/user.cpp
@@ -6,7 +6,6 @@ namespace user{
 
 
 User::User(string username) : semaphore(1) {
-    cout << "Semaphore number (User constructor): " << &this->semaphore << endl;
     this->initSessionList();
     this->username = username;
 }
@@ -35,7 +34,6 @@ void User::getActiveSockets(int* activeSocketsResult) {
 }
 
 int User::registerSession(int socket) {
-    cout << "Semaphore number (registerSession): " << &this->semaphore << endl;
     this->semaphore.wait();
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS; i++) {
         if (this->sockets[i] == 0){

--- a/Instant-Messenger/src/util/user.cpp
+++ b/Instant-Messenger/src/util/user.cpp
@@ -1,74 +1,64 @@
 #include "../../include/util/user.hpp"
 #include <sstream>
 #include <iostream>
-
-sem_t semaphore;
+#include <thread>
 
 namespace user{
 
-User::User() {
-    init_semaphore();
-    wait_semaphore();
+
+User::User(string username) : semaphore(1) {
+    cout << "Semaphore number (User constructor): " << &this->semaphore << endl;
+    this->initSessionList();
+    this->username = username;
+}
+
+void User::initSessionList() {
+    this->semaphore.wait();
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS; i++) {
         this->sockets[i] = 0;
     }
-    post_semaphore();
+    this->semaphore.post();
 }
 
-User::User(string username) {
-    User();
-    this->username = username;
-}
 
 string User::getUsername() {
     return this->username;
 }
 
 void User::getActiveSockets(int* activeSocketsResult) {
-    wait_semaphore();
+    this->semaphore.wait();
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS ; i++) {
         if (this->sockets[i] != 0) {
             activeSocketsResult[i] = this->sockets[i];
         }
     }
-    post_semaphore();
+    this->semaphore.post();
 }
 
 int User::registerSession(int socket) {
-    wait_semaphore();
+    cout << "Semaphore number (registerSession): " << &this->semaphore << endl;
+    this->semaphore.wait();
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS; i++) {
         if (this->sockets[i] == 0){
             this->sockets[i] = socket;
-            post_semaphore();
+            this->semaphore.post();
             return 0;
         }
     }
-    post_semaphore();
+    this->semaphore.post();
     return  -1;
 }
 
 void User::releaseSession(int socket) {
-    wait_semaphore();
+    this->semaphore.wait();
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS; i++) {
         if (this->sockets[i] == socket){
             this->sockets[i] = 0;
-            post_semaphore();
+            this->semaphore.post();
             return;
         }
     }
-    post_semaphore();
-}
-
-void User::init_semaphore() {
-    sem_init(&semaphore, 0, 1);
-}
-
-void User::wait_semaphore() {
-    sem_wait(&semaphore);
-}
-
-void User::post_semaphore() {
-    sem_post(&semaphore);
+    this->semaphore.post();
 }
 
 } // namespace user;

--- a/Instant-Messenger/src/util/user.cpp
+++ b/Instant-Messenger/src/util/user.cpp
@@ -41,7 +41,7 @@ int User::registerSession(int socket) {
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS; i++) {
         if (this->sockets[i] == 0){
             this->sockets[i] = socket;
-            this->semaphore.post();
+            // this->semaphore.post();
             return 0;
         }
     }

--- a/Instant-Messenger/src/util/user.cpp
+++ b/Instant-Messenger/src/util/user.cpp
@@ -1,7 +1,6 @@
 #include "../../include/util/user.hpp"
 #include <sstream>
 #include <iostream>
-#include <thread>
 
 namespace user{
 
@@ -41,7 +40,7 @@ int User::registerSession(int socket) {
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_CONNECTIONS; i++) {
         if (this->sockets[i] == 0){
             this->sockets[i] = socket;
-            // this->semaphore.post();
+            this->semaphore.post();
             return 0;
         }
     }


### PR DESCRIPTION
Implementa semáforos como uma classe usando mutex e variável de condição. Dessa forma a gente consegue ter um semáforo comum para cada instância de User. Poderemos usar essa classe para proteger outros recursos, posteriormente.

Antes o sem_t semaphore estava global (funcionava mas era comum para todos os users). Quando tentávamos utilizá-lo por instância não funcionava, sempre tínhamos outro semáforo roando em outro endereço de memória.

Aqui vão dois testes que embasam e confirmam o fix:

![image](https://user-images.githubusercontent.com/23477064/94992624-bdd8ca00-0561-11eb-8d1e-ce10ef32ca85.png)
1. Antes da mensagem de teste a gente tem duas sessões rodando para o mesmo usuário (os endereços do semáforo são os mesmos.
1. Depois da mensagem de teste, outro usuário logou e obteve outro valor para o endereço de semáforo.

Também testei tirando um post do semáforo e o client ficou preso no wait.
