### PR TITLE
Changes the implementation to an array of messages

### DIFF
--- a/Instant-Messenger/Makefile
+++ b/Instant-Messenger/Makefile
@@ -15,10 +15,10 @@ build-server:
 	$(SRC_DIR)/server/server_group_manager.cpp $(SRC_DIR)/server/server_message_manager.cpp $(SRC_DIR)/util/user.cpp
 
 run-client:
-	$(BUILD_DIR)/client.app JohnnyUser2 SampleRoom2 127.0.0.1 4040
+	$(BUILD_DIR)/client.app JohnnyUser1 SampleRoom1 127.0.0.1 4041
 
 run-server:
-	$(BUILD_DIR)/server.app 4040
+	$(BUILD_DIR)/server.app 4041
 
 clean:
 	rm -rf $(SRC_DIR)/*~ $(INC_DIR)/*~ client server *~

--- a/Instant-Messenger/include/util/file_system_manager.hpp
+++ b/Instant-Messenger/include/util/file_system_manager.hpp
@@ -28,6 +28,6 @@ class FileSystemManager {
         FileSystemManager();
         void prepareDirectory();
         void appendGroupMessageToHistory(Message message);
-        std::vector< std::vector<std::string> > readGroupHistoryMessages(string groupName);        
+        std::vector< Message > readGroupHistoryMessages(string groupName);
 };
 } // namespace filesystemmanager;

--- a/Instant-Messenger/src/util/file_system_manager.cpp
+++ b/Instant-Messenger/src/util/file_system_manager.cpp
@@ -35,19 +35,18 @@ void FileSystemManager::appendGroupMessageToHistory(Message message) {
     semaphore.post();
 }
 
-std::vector<std::vector<std::string> > FileSystemManager::readGroupHistoryMessages(string groupName) {
+std::vector<Message> FileSystemManager::readGroupHistoryMessages(string groupName) {
     semaphore.wait();
     std::string line;
-    std::vector<std::vector<std::string> > parsedCsv;
     std::stringstream groupFile;
     groupFile << MESSAGES_BASE_PATH << PATH_SEPARATOR << groupName << FILE_EXTENSION;
     std::ifstream data;
-    
+    std::vector <Message> messages;
+
     data.open(groupFile.str());
 
     while(std::getline(data,line))
     {
-        cout << line << endl;
         std::stringstream lineStream(line);
         std::string cell;
         std::vector<std::string> parsedRow;
@@ -56,13 +55,20 @@ std::vector<std::vector<std::string> > FileSystemManager::readGroupHistoryMessag
             parsedRow.push_back(cell);
         }
 
-        parsedCsv.push_back(parsedRow);
+        stringstream intTime(parsedRow[2]);
+
+        long int time = 0;
+        intTime >> time;
+        Message message = Message((string) parsedRow[1], (string) parsedRow[0], groupName, time);
+
+        messages.push_back(message);
+
     }
 
     data.close();
     semaphore.post();
 
-    return parsedCsv;
+    return messages;
 }
 
 } // namespace filesystemmanager;


### PR DESCRIPTION
Returns a list of messages instead of a list of vectors when getting the history in the filesystem manager.