### PR TITLE
Fixes fe identifier in server

### DIFF
--- a/Instant-Messenger/CMakeLists.txt
+++ b/Instant-Messenger/CMakeLists.txt
@@ -45,6 +45,6 @@ add_executable(Instant_Messenger
         src/util/Socket.cpp
         src/util/user.cpp src/util/ConnectionKeeper.cpp include/util/ConnectionKeeper.hpp src/util/ConnectionMonitor.cpp include/util/ConnectionMonitor.hpp
         src/util/Uuid.cpp
-        include/util/StringConstants.hpp src/util/StringConstants.cpp)
+        include/util/StringConstants.hpp src/util/StringConstants.cpp src/server/FeAddressBook.cpp include/server/FeAddressBook.hpp)
 
 target_link_libraries( Instant_Messenger ${CMAKE_THREAD_LIBS_INIT})

--- a/Instant-Messenger/Makefile
+++ b/Instant-Messenger/Makefile
@@ -14,7 +14,7 @@ build-client:	Socket.o Semaphore.o Uuid.o ConnectionKeeper.o
 
 build-server:	Socket.o Semaphore.o Uuid.o ConnectionKeeper.o
 	${CC} -pthread -std=c++11 -g -o $(BUILD_DIR)/server.app Socket.o Uuid.o $(SRC_DIR)/util/message.cpp $(SRC_DIR)/util/file_system_manager.cpp Semaphore.o $(SRC_DIR)/app/app_server.cpp $(SRC_DIR)/server/server.cpp \
-	$(SRC_DIR)/server/server_group_manager.cpp $(SRC_DIR)/server/server_message_manager.cpp $(SRC_DIR)/util/user.cpp $(SRC_DIR)/server/Group.cpp $(SRC_DIR)/util/ConnectionMonitor.cpp ConnectionKeeper.o $(SRC_DIR)/util/StringConstants.cpp
+	$(SRC_DIR)/server/server_group_manager.cpp $(SRC_DIR)/server/server_message_manager.cpp $(SRC_DIR)/util/user.cpp $(SRC_DIR)/server/Group.cpp $(SRC_DIR)/util/ConnectionMonitor.cpp ConnectionKeeper.o $(SRC_DIR)/util/StringConstants.cpp $(SRC_DIR)/server/FeAddressBook.cpp
 
 build-proxy_fe:	Socket.o Semaphore.o Uuid.o ConnectionKeeper.o
 	${CC} -pthread -std=c++11 -g -o $(BUILD_DIR)/proxy_fe.app Socket.o Uuid.o Semaphore.o $(SRC_DIR)/app/app_proxy_fe.cpp \

--- a/Instant-Messenger/include/server/FeAddressBook.hpp
+++ b/Instant-Messenger/include/server/FeAddressBook.hpp
@@ -1,0 +1,31 @@
+//
+// Created by gabriel on 11/21/20.
+//
+
+#ifndef INSTANT_MESSENGER_FEADDRESSBOOK_HPP
+#define INSTANT_MESSENGER_FEADDRESSBOOK_HPP
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <map>
+#include "../util/Semaphore.hpp"
+
+using namespace std;
+
+class FeAddressBook {
+
+private:
+    std::map<string, int> serverAddressToInternalSocket;
+    Semaphore* feAddressBookSemaphore;
+
+public:
+    FeAddressBook();
+    int getInternalSocketId(string feAddress);
+    void registryAddressSocket(string feAddress, int socketId);
+    void removeServerSocket(string feAddress);
+};
+
+
+#endif //INSTANT_MESSENGER_FEADDRESSBOOK_HPP

--- a/Instant-Messenger/include/server/Group.hpp
+++ b/Instant-Messenger/include/server/Group.hpp
@@ -18,7 +18,7 @@ class Group
 
 	public:
 		Group();
-        Group(string groupName, FeAddressBook feAddressBook);
+        Group(string groupName, FeAddressBook* feAddressBook);
         filesystemmanager::FileSystemManager* fsManager;
         servermessagemanager::ServerMessageManager *messageManager;
         pthread_t tid;
@@ -42,7 +42,7 @@ class Group
         void sendActivityMessage(const string &userName, const string &actionText);
         void disconnectSession(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser);
         User *getUserFromConnectionId(string clientID, string feAddress) const;
-        FeAddressBook feAddressBook;
+        FeAddressBook* feAddressBook;
 };
 
 #endif

--- a/Instant-Messenger/include/server/Group.hpp
+++ b/Instant-Messenger/include/server/Group.hpp
@@ -10,6 +10,7 @@
 #include "../util/Semaphore.hpp"
 #include "../util/file_system_manager.hpp"
 #include "../server/server_message_manager.hpp"
+#include "FeAddressBook.hpp"
 
 using namespace std;
 class Group
@@ -17,7 +18,7 @@ class Group
 
 	public:
 		Group();
-        Group(string groupName);
+        Group(string groupName, FeAddressBook feAddressBook);
         filesystemmanager::FileSystemManager* fsManager;
         servermessagemanager::ServerMessageManager *messageManager;
         pthread_t tid;
@@ -28,20 +29,20 @@ class Group
         std::queue<message::Message> messages_queue;  
         string groupName;
         static void *consumeMessageQueue(void * args);
-        int registerNewSession(char *clientID, int feSocket, string userName);
+        int registerNewSession(string clientID, string feAddress, string userName);
         void processReceivedMessage(string userName, string message);
-        void handleDisconnectEvent(char *clientID, int feSocket, map<string, int> &numberOfConnectionsByUser);
+        void handleDisconnectEvent(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser);
         void configureFileSystemManager(int maxNumberOfMessagesOnHistory);
 
     private:
-        vector<pair<char *, int>> getAllActiveConnectionIds();
-        void sendAcceptToUser(char *clientID, int feSocket);
-        void sendHistoryToUser(char *clientID, int feSocket);
+        vector<pair<string, string>> getAllActiveConnectionIds();
+        void sendAcceptToUser(string clientID, string feAddress);
+        void sendHistoryToUser(string clientID, string feAddress);
         void addMessageToMessageQueue(Message message);
         void sendActivityMessage(const string &userName, const string &actionText);
-        void disconnectSession(char *clientID, int feSocket, map<string, int> &numberOfConnectionsByUser);
-        User *getUserFromConnectionId(char *clientID, int feSocket) const;
-
+        void disconnectSession(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser);
+        User *getUserFromConnectionId(string clientID, string feAddress) const;
+        FeAddressBook feAddressBook;
 };
 
 #endif

--- a/Instant-Messenger/include/server/server.hpp
+++ b/Instant-Messenger/include/server/server.hpp
@@ -19,6 +19,8 @@
 #include "../util/Socket.hpp"
 #include "../util/Semaphore.hpp"
 #include "../util/ConnectionMonitor.hpp"
+#include "FeAddressBook.hpp"
+
 
 #define MAXBACKLOG SOMAXCONN
 
@@ -37,7 +39,7 @@ namespace server {
         static void * monitorConnection(void *args);
         void closeFrontEndConnection(int socketId);
         pthread_t tid[MAXBACKLOG];
-
+        FeAddressBook feAddressBook;
 
     public:
         Server();

--- a/Instant-Messenger/include/server/server.hpp
+++ b/Instant-Messenger/include/server/server.hpp
@@ -33,13 +33,14 @@ namespace server {
         ConnectionMonitor *connectionMonitor;
 
         struct sockaddr_in serv_addr;
-        void closeClientConnection(pair<char *, int> clientConnectionId);
+        void closeClientConnection(pair<string, string> clientConnectionId);
         std::map<string, int> connectionsCount;
         int limitOfConnectios;
         static void * monitorConnection(void *args);
-        void closeFrontEndConnection(int socketId);
+        void closeFrontEndConnection(string feAddress);
         pthread_t tid[MAXBACKLOG];
         FeAddressBook feAddressBook;
+        vector<string> feAddresses;
 
     public:
         Server();
@@ -47,14 +48,14 @@ namespace server {
         static std::vector<int> openSockets;
         Semaphore* sockets_connections_semaphore;
         Semaphore* feConnectionInitializationSemaphore;
-        Semaphore* feSocketsSemaphore;
+        Semaphore* feAddressesSemaphore;
         static void closeClientConnection(int socket_fd);
         static void *listenFrontEndCommunication(void *newsocket);
         void setPort(int port);
         void prepareConnection();
         void printPortNumber();
-        int registerUserToServer(Packet *registrationPacket, int frontEndSocket);
-        int registerUser(pair<char *, int> clientIdentifier, char *username, char *group);
+        int registerUserToServer(Packet *registrationPacket, string feAddress);
+        int registerUser(pair<string, string> clientIdentifier, char *username, char *group);
         int connectToFE(string feAddress, int fePort);
         int handleFrontEndsConnections();
         void closeFrontEndConnections();
@@ -67,7 +68,9 @@ namespace server {
         int getNumberOfConnectionsByUser(string user);
         int incrementNumberOfConnectionsFromUser(string user);
 
-        void eraseSocketFromFeSocketList(int socketId);
+        void purgeFeConnection(string feAddress);
+
+        int getSocketFromAddress(const string feAddress);
     };
 }
 #endif

--- a/Instant-Messenger/include/server/server.hpp
+++ b/Instant-Messenger/include/server/server.hpp
@@ -39,7 +39,7 @@ namespace server {
         static void * monitorConnection(void *args);
         void closeFrontEndConnection(string feAddress);
         pthread_t tid[MAXBACKLOG];
-        FeAddressBook feAddressBook;
+        FeAddressBook* feAddressBook;
         vector<string> feAddresses;
 
     public:

--- a/Instant-Messenger/include/server/server_group_manager.hpp
+++ b/Instant-Messenger/include/server/server_group_manager.hpp
@@ -31,10 +31,10 @@ namespace servergroupmanager {
             std::map<string,Group*> groupMap; // will maintain a map of groupName -> group. This will be used to route the calls to the proper group
             bool groupExists(string groupName);
             int maxNumberOfMessagesOnHistory;
-            FeAddressBook feAddressBook;
+            FeAddressBook* feAddressBook;
 
         public:
-            ServerGroupManager(FeAddressBook feAddressBook);
+            ServerGroupManager(FeAddressBook* feAddressBook);
             int registerUserToGroup(pair<string, string> clientIdentifier, string username, string groupName);
             void processReceivedPacket(Packet* packet);
             void propagateSocketDisconnectionEvent(pair<string, string> connectionId, map<string, int> &numberOfConnectionsByUser);

--- a/Instant-Messenger/include/server/server_group_manager.hpp
+++ b/Instant-Messenger/include/server/server_group_manager.hpp
@@ -34,11 +34,10 @@ namespace servergroupmanager {
             FeAddressBook feAddressBook;
 
         public:
-            ServerGroupManager();
             ServerGroupManager(FeAddressBook feAddressBook);
-            int registerUserToGroup(pair<char *, int> clientIdentifier, string username, string groupName);
+            int registerUserToGroup(pair<string, string> clientIdentifier, string username, string groupName);
             void processReceivedPacket(Packet* packet);
-            void propagateSocketDisconnectionEvent(pair<char *, int> connectionId, map<string, int> &numberOfConnectionsByUser);
+            void propagateSocketDisconnectionEvent(pair<string, string> connectionId, map<string, int> &numberOfConnectionsByUser);
             void configureFileSystemManager(int maxNumberOfMessagesOnHistory);
 
     };

--- a/Instant-Messenger/include/server/server_group_manager.hpp
+++ b/Instant-Messenger/include/server/server_group_manager.hpp
@@ -7,6 +7,7 @@
 #include "../server/server_message_manager.hpp"
 #include "../util/Packet.hpp"
 #include "./Group.hpp"
+#include "FeAddressBook.hpp"
 
 #include <string>
 #include <iostream>
@@ -30,9 +31,11 @@ namespace servergroupmanager {
             std::map<string,Group*> groupMap; // will maintain a map of groupName -> group. This will be used to route the calls to the proper group
             bool groupExists(string groupName);
             int maxNumberOfMessagesOnHistory;
+            FeAddressBook feAddressBook;
 
         public:
             ServerGroupManager();
+            ServerGroupManager(FeAddressBook feAddressBook);
             int registerUserToGroup(pair<char *, int> clientIdentifier, string username, string groupName);
             void processReceivedPacket(Packet* packet);
             void propagateSocketDisconnectionEvent(pair<char *, int> connectionId, map<string, int> &numberOfConnectionsByUser);

--- a/Instant-Messenger/include/server/server_message_manager.hpp
+++ b/Instant-Messenger/include/server/server_message_manager.hpp
@@ -14,13 +14,13 @@ namespace servermessagemanager {
 
     class ServerMessageManager : public Socket{
     public:
-        ServerMessageManager(FeAddressBook feAddressBook);
+        ServerMessageManager(FeAddressBook *feAddressBook);
         void broadcastMessageToUsers(Message message, vector< pair <string, string> > connectionIds);
         void sendMessageToSession(Message message, string clientID, string feAddress);
         void sendPacketToSocketId(Packet* packet, string feAddress);
         void sendMessageToAddress(Message message, string clientId, string feAddress);
     private:
-        FeAddressBook feAddressBook;
+        FeAddressBook *feAddressBook;
         void sendMessageToSocketId(Message message, string clientID, int feSocket); //An aux to send the message when we already converted the address to the actual socket id
         int getSocketFromAddress(const string &feAddress);
     };

--- a/Instant-Messenger/include/server/server_message_manager.hpp
+++ b/Instant-Messenger/include/server/server_message_manager.hpp
@@ -5,6 +5,7 @@
 #include "../util/message.hpp"
 #include "../util/user.hpp"
 #include "../util/Socket.hpp"
+#include "FeAddressBook.hpp"
 
 using namespace message;
 using namespace user;
@@ -12,10 +13,20 @@ using namespace user;
 namespace servermessagemanager {
 
     class ServerMessageManager : public Socket{
-        public:
+    public:
+        ServerMessageManager(FeAddressBook feAddressBook);
         void broadcastMessageToUsers(Message message, vector< pair <char *, int> > connectionIds);
         void sendMessageToSocketId(Message message, char *clientID, int feSocket);
         void sendPacketToSocketId(Packet* packet, int socket);
+
+        void sendMessageToAddress(Message message, string clientId, string feAddress);
+
+    private:
+        FeAddressBook feAddressBook;
+
+        void sendMessageToSocketId(Message message, string clientID, string feAddress);
+
+        void sendMessageToSocketId(Message message, string clientID, int feSocket);
     };
 }
 

--- a/Instant-Messenger/include/server/server_message_manager.hpp
+++ b/Instant-Messenger/include/server/server_message_manager.hpp
@@ -15,18 +15,14 @@ namespace servermessagemanager {
     class ServerMessageManager : public Socket{
     public:
         ServerMessageManager(FeAddressBook feAddressBook);
-        void broadcastMessageToUsers(Message message, vector< pair <char *, int> > connectionIds);
-        void sendMessageToSocketId(Message message, char *clientID, int feSocket);
-        void sendPacketToSocketId(Packet* packet, int socket);
-
+        void broadcastMessageToUsers(Message message, vector< pair <string, string> > connectionIds);
+        void sendMessageToSession(Message message, string clientID, string feAddress);
+        void sendPacketToSocketId(Packet* packet, string feAddress);
         void sendMessageToAddress(Message message, string clientId, string feAddress);
-
     private:
         FeAddressBook feAddressBook;
-
-        void sendMessageToSocketId(Message message, string clientID, string feAddress);
-
-        void sendMessageToSocketId(Message message, string clientID, int feSocket);
+        void sendMessageToSocketId(Message message, string clientID, int feSocket); //An aux to send the message when we already converted the address to the actual socket id
+        int getSocketFromAddress(const string &feAddress);
     };
 }
 

--- a/Instant-Messenger/include/util/user.hpp
+++ b/Instant-Messenger/include/util/user.hpp
@@ -20,21 +20,21 @@ class User {
 
     private:
         string username;
-        std::vector<pair <char *, int> > clientIdentifiers; // clientID, feSocket
+        std::vector<pair <string, string> > clientIdentifiers; // clientID, feSocket
         Semaphore semaphore;
     
     public:
         User(string username);
         string getUsername();
-        std::vector<pair<char *, int>> getActiveConnections();
+        std::vector<pair<string, string>> getActiveConnections();
 
         /*
         * Method to register a socket linked to a user
         * throws USER_SESSIONS_LIMIT_REACHED if the addition
         * was not created due to limitation reached
         */
-        int registerSession(char *clientID, int feSocket);
-        void releaseSession(char *clientID, int feSocket);
+        int registerSession(string clientID, string feAddress);
+        void releaseSession(string clientID, string feAddress);
         void initSessionList();
 
         bool operator == (const User& s) const { return username == s.username; }

--- a/Instant-Messenger/messages/SampleRoom2.csv
+++ b/Instant-Messenger/messages/SampleRoom2.csv
@@ -2,3 +2,5 @@ JohnnyUser2asd1602383780
 JohnnyUser2gabe is testing it1602383788
 JohnnyUser2abe tested 1602383794
 JohnnyUser2tes, asd,asd asd,a 1602383802
+Gabe2teste1605995057
+Gabe21231231605995062

--- a/Instant-Messenger/src/server/FeAddressBook.cpp
+++ b/Instant-Messenger/src/server/FeAddressBook.cpp
@@ -1,0 +1,27 @@
+#include "../../include/server/FeAddressBook.hpp"
+
+
+FeAddressBook::FeAddressBook() {
+    this->serverAddressToInternalSocket = map<string, int>();
+    this->feAddressBookSemaphore = new Semaphore(1);
+}
+
+int FeAddressBook::getInternalSocketId(string feAddress) {
+    int socket;
+    feAddressBookSemaphore->wait();
+    socket = this->serverAddressToInternalSocket[feAddress];
+    feAddressBookSemaphore->post();
+    return socket;
+}
+
+void FeAddressBook::registryAddressSocket(string feAddress, int socketId) {
+    feAddressBookSemaphore->wait();
+    this->serverAddressToInternalSocket[feAddress] = socketId;
+    feAddressBookSemaphore->post();
+}
+
+void FeAddressBook::removeServerSocket(string feAddress) {
+    feAddressBookSemaphore->wait();
+    this->serverAddressToInternalSocket.erase(feAddress);
+    feAddressBookSemaphore->post();
+}

--- a/Instant-Messenger/src/server/Group.cpp
+++ b/Instant-Messenger/src/server/Group.cpp
@@ -2,17 +2,20 @@
 #include "../../include/util/StringConstants.hpp"
 #include <algorithm>
 
+
 using namespace std;
 
-Group::Group(string name)
+Group::Group(string name, FeAddressBook feAddressBook)
 {
     this->groupName = name;
     fsManager = new filesystemmanager::FileSystemManager();
-    messageManager = new servermessagemanager::ServerMessageManager();
+    messageManager = new servermessagemanager::ServerMessageManager(feAddressBook);
 
     // Init semaphores
     messageQueueSemaphore = new Semaphore(1);
     usersSemaphore = new Semaphore(1);
+
+    this->feAddressBook = feAddressBook;
 
     // Init consumer/producer mutex
     pthread_mutex_init(&mutex_consumer_producer, NULL);
@@ -70,13 +73,13 @@ void * Group::consumeMessageQueue(void * args)
  * @param clientID
  * @param feSocket
  */
-void Group::sendAcceptToUser(char *clientID, int feSocket)
+void Group::sendAcceptToUser(string clientID, string feAddress)//TODO: update
 {
     Packet *pack = new Packet();
     pack->type = ACCEPT_PACKET;
-    strcpy(pack->user_id, clientID);
-    std::cout << "[DEBUG] mandei ACCEPT para socket: " << feSocket << std::endl;
-    messageManager->sendPacketToSocketId(pack, feSocket);
+    strcpy(pack->user_id, clientID.c_str());
+    std::cout << "[DEBUG] mandei ACCEPT para socket: " << feAddress << std::endl;
+    messageManager->sendPacketToSocketId(pack, feAddress); // TODO: update this in the message manager
 }
 
 /**
@@ -92,11 +95,11 @@ void Group::sendAcceptToUser(char *clientID, int feSocket)
  * @param groupName
  * @return returns a negative number in case of a failure
  */
-int Group::registerNewSession(char *clientID, int feSocket, string userName) {
+int Group::registerNewSession(string clientID, string feAddress, string userName) { //TODO: update to string,string
     User* user = NULL;
     int result = 0;
-    sendAcceptToUser(clientID, feSocket);
-    sendHistoryToUser(clientID, feSocket);
+    sendAcceptToUser(clientID, feAddress);
+    sendHistoryToUser(clientID, feAddress);
     usersSemaphore->wait();
     for (auto userItr : this->users) {
         if ( userName.compare(userItr->getUsername()) == 0 ) {
@@ -107,10 +110,10 @@ int Group::registerNewSession(char *clientID, int feSocket, string userName) {
     if ( user == NULL) { // if user does not exists in the list, we create the entry in the list
         user = new User(userName);
         this->users.push_back(user);
-        result = user->registerSession(clientID, feSocket);
+        result = user->registerSession(clientID, feAddress);
         sendActivityMessage(userName, JOINED_MESSAGE); // Se a pessoa já está no grupo, não deve-se enviar uma nova mensagem dizendo que ela ingressou no grupo. (copiei do moodle esse statement)
     } else {
-        result = user->registerSession(clientID, feSocket);
+        result = user->registerSession(clientID, feAddress);
     }
     usersSemaphore->post();
     return result;
@@ -121,22 +124,22 @@ int Group::registerNewSession(char *clientID, int feSocket, string userName) {
  *
  * @param feSocket
  */
-void Group::handleDisconnectEvent(char *clientID, int feSocket, map<string, int> &numberOfConnectionsByUser) {
+void Group::handleDisconnectEvent(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser) { //TODO: update this to string,string
     usersSemaphore->wait();
-    vector<pair <char *, int> > allActiveSockets = this->getAllActiveConnectionIds();
+    vector<pair <string, string> > allActiveSockets = this->getAllActiveConnectionIds();
 
-    if ( strcmp(clientID, FE_DISCONNECT) == 0 ) { // DELETE ALL CONNECTIONS FROM THE CLIENTS THAT WERE CONNECTED TO THE FE
+    if ( clientID.compare(FE_DISCONNECT) == 0 ) { // DELETE ALL CONNECTIONS FROM THE CLIENTS THAT WERE CONNECTED TO THE FE
         for (auto groupConnection : allActiveSockets) {
-            if (groupConnection.second == feSocket) { // if there is a match in the FE socket ID
+            if (groupConnection.second.compare(feAddress) == 0) { // if there is a match in the FE socket ID
                 cout << "[FE disconnect] Killing clientConnection [" << groupConnection.first << "," << groupConnection.second << "]"
                      << endl;
-                this->disconnectSession(groupConnection.first, feSocket, numberOfConnectionsByUser);
+                this->disconnectSession(groupConnection.first, feAddress, numberOfConnectionsByUser); //TODO: update this to string,string
             }
         }
     } else {
-        cout << "[Client disconnect] Killing clientConnection [" << clientID << "," << feSocket << "]"
+        cout << "[Client disconnect] Killing clientConnection [" << clientID << "," << feAddress << "]"
              << endl;
-        this->disconnectSession(clientID, feSocket, numberOfConnectionsByUser);
+        this->disconnectSession(clientID, feAddress, numberOfConnectionsByUser); //TODO: update this to string,string
     }
     usersSemaphore->post();
 }
@@ -151,12 +154,12 @@ void Group::handleDisconnectEvent(char *clientID, int feSocket, map<string, int>
  *  it is already thread safe by the call (handleDisconnectEvent)
  * @param feSocket
  */
-void Group::disconnectSession(char *clientID, int feSocket, map<string, int> &numberOfConnectionsByUser) {
-    user::User* user = getUserFromConnectionId(clientID, feSocket);
-    cout << "disconnectSession  [" << clientID << "," << feSocket << "]" << endl;
+void Group::disconnectSession(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser) { //TODO: update this to string,string
+    user::User* user = getUserFromConnectionId(clientID, feAddress);
+    cout << "disconnectSession  [" << clientID << "," << feAddress << "]" << endl;
     if ( user != NULL) {
-        numberOfConnectionsByUser[user->getUsername()] -= 1;
-        user->releaseSession(clientID, feSocket);
+        numberOfConnectionsByUser[user->getUsername()] -= 1; //TODO: check for the necessity of a semaphore here
+        user->releaseSession(clientID, feAddress);
         if (user->getActiveConnections().size() < 1) {
             sendActivityMessage(user->getUsername(), LEFT_GROUP_MESSAGE);
             users.remove(user);
@@ -181,13 +184,13 @@ void Group::sendActivityMessage(const string &userName, const string &actionText
  * It can help you to welcome new users and introduce them to the discussed topics
  * @param feSocket
  */
-void Group::sendHistoryToUser(char *clientID, int feSocket) {
+void Group::sendHistoryToUser(string clientID, string feAddress) {
     std::vector<Message> messages = fsManager->readGroupHistoryMessages(this->groupName);
     cout << "Vou printar as mensagens do user " << endl;
     messageQueueSemaphore->wait();
     for(auto  message : messages) {
         message.setIsNotification(true);
-        messageManager->sendMessageToSocketId(message, clientID, feSocket);
+        messageManager->sendMessageToAddress(message, clientID, feAddress);
     }
     messageQueueSemaphore->post();
 }

--- a/Instant-Messenger/src/server/Group.cpp
+++ b/Instant-Messenger/src/server/Group.cpp
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-Group::Group(string name, FeAddressBook feAddressBook)
+Group::Group(string name, FeAddressBook* feAddressBook)
 {
     this->groupName = name;
     fsManager = new filesystemmanager::FileSystemManager();
@@ -95,7 +95,7 @@ void Group::sendAcceptToUser(string clientID, string feAddress)
  * @param groupName
  * @return returns a negative number in case of a failure
  */
-int Group::registerNewSession(string clientID, string feAddress, string userName) { //TODO: update to string,string
+int Group::registerNewSession(string clientID, string feAddress, string userName) {
     User* user = NULL;
     int result = 0;
     sendAcceptToUser(clientID, feAddress);
@@ -110,11 +110,10 @@ int Group::registerNewSession(string clientID, string feAddress, string userName
     if ( user == NULL) { // if user does not exists in the list, we create the entry in the list
         user = new User(userName);
         this->users.push_back(user);
-        result = user->registerSession(clientID, feAddress);
-        sendActivityMessage(userName, JOINED_MESSAGE); // Se a pessoa já está no grupo, não deve-se enviar uma nova mensagem dizendo que ela ingressou no grupo. (copiei do moodle esse statement)
-    } else {
-        result = user->registerSession(clientID, feAddress);
+        sendActivityMessage(userName, JOINED_MESSAGE); // se a pessoa é nova no grupo, a gente manda uma mensagem de join para todos
     }
+
+    result = user->registerSession(clientID, feAddress);
     usersSemaphore->post();
     return result;
 }

--- a/Instant-Messenger/src/server/Group.cpp
+++ b/Instant-Messenger/src/server/Group.cpp
@@ -73,13 +73,13 @@ void * Group::consumeMessageQueue(void * args)
  * @param clientID
  * @param feSocket
  */
-void Group::sendAcceptToUser(string clientID, string feAddress)//TODO: update
+void Group::sendAcceptToUser(string clientID, string feAddress)
 {
     Packet *pack = new Packet();
     pack->type = ACCEPT_PACKET;
     strcpy(pack->user_id, clientID.c_str());
     std::cout << "[DEBUG] mandei ACCEPT para socket: " << feAddress << std::endl;
-    messageManager->sendPacketToSocketId(pack, feAddress); // TODO: update this in the message manager
+    messageManager->sendPacketToSocketId(pack, feAddress);
 }
 
 /**
@@ -124,7 +124,7 @@ int Group::registerNewSession(string clientID, string feAddress, string userName
  *
  * @param feSocket
  */
-void Group::handleDisconnectEvent(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser) { //TODO: update this to string,string
+void Group::handleDisconnectEvent(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser) {
     usersSemaphore->wait();
     vector<pair <string, string> > allActiveSockets = this->getAllActiveConnectionIds();
 
@@ -133,13 +133,13 @@ void Group::handleDisconnectEvent(string clientID, string feAddress, map<string,
             if (groupConnection.second.compare(feAddress) == 0) { // if there is a match in the FE socket ID
                 cout << "[FE disconnect] Killing clientConnection [" << groupConnection.first << "," << groupConnection.second << "]"
                      << endl;
-                this->disconnectSession(groupConnection.first, feAddress, numberOfConnectionsByUser); //TODO: update this to string,string
+                this->disconnectSession(groupConnection.first, feAddress, numberOfConnectionsByUser);
             }
         }
     } else {
         cout << "[Client disconnect] Killing clientConnection [" << clientID << "," << feAddress << "]"
              << endl;
-        this->disconnectSession(clientID, feAddress, numberOfConnectionsByUser); //TODO: update this to string,string
+        this->disconnectSession(clientID, feAddress, numberOfConnectionsByUser);
     }
     usersSemaphore->post();
 }
@@ -154,7 +154,7 @@ void Group::handleDisconnectEvent(string clientID, string feAddress, map<string,
  *  it is already thread safe by the call (handleDisconnectEvent)
  * @param feSocket
  */
-void Group::disconnectSession(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser) { //TODO: update this to string,string
+void Group::disconnectSession(string clientID, string feAddress, map<string, int> &numberOfConnectionsByUser) {
     user::User* user = getUserFromConnectionId(clientID, feAddress);
     cout << "disconnectSession  [" << clientID << "," << feAddress << "]" << endl;
     if ( user != NULL) {
@@ -211,10 +211,10 @@ void Group::processReceivedMessage(string userName, string message) {
  * @param feSocket
  * @return
  */
-User *Group::getUserFromConnectionId(char *clientID, int feSocket) const {
+User *Group::getUserFromConnectionId(string clientID, string feAddress) const {
     for (auto user : users) {
         for (auto userConnection : user->getActiveConnections()) {
-            if ( ( strcmp(clientID, userConnection.first) == 0) && ( feSocket == userConnection.second ) )  {
+            if ( ( clientID.compare(userConnection.first) == 0) && ( feAddress.compare(userConnection.second) == 0 ) )  {
                 return user;
             }
         }
@@ -238,11 +238,11 @@ void Group::addMessageToMessageQueue(Message message) {
  * Can you guess what this method does?
  * @return list of sockets
  */
-vector<pair<char *, int>> Group::getAllActiveConnectionIds() {
-    vector< pair <char *, int> > connectionIds = vector< pair<char *, int> >();
+vector<pair<string, string>> Group::getAllActiveConnectionIds() {
+    vector< pair <string, string> > connectionIds = vector< pair<string, string> >();
     for (auto user : this->users) {
-        for (auto userActiveSocket : user->getActiveConnections()) {
-            connectionIds.push_back(userActiveSocket);
+        for (auto userActiveSession : user->getActiveConnections()) {
+            connectionIds.push_back(userActiveSession);
         }
     }
     return connectionIds;

--- a/Instant-Messenger/src/server/server.cpp
+++ b/Instant-Messenger/src/server/server.cpp
@@ -21,18 +21,12 @@ namespace server {
         sockets_connections_semaphore = new Semaphore(1);
         feConnectionInitializationSemaphore = new Semaphore(1);
         feSocketsSemaphore = new Semaphore(1);
-        groupManager = new ServerGroupManager();
+
         connectionMonitor = new ConnectionMonitor();
 
-        // TODO assim como proxyFE, o server vai ter que ter 2 sockets, um pra conectar nos FE e outro nos RM
-        {
-            // Configure server address properties
-            // serv_addr.sin_family = AF_INET;
-            // serv_addr.sin_addr.s_addr = INADDR_ANY;
-            // bzero(&(serv_addr.sin_zero), 8);
-        }
         socketFeList = vector<int>();
         this->feAddressBook = FeAddressBook();
+        groupManager = new ServerGroupManager(this->feAddressBook);
 
     }
 

--- a/Instant-Messenger/src/server/server.cpp
+++ b/Instant-Messenger/src/server/server.cpp
@@ -16,26 +16,32 @@
 namespace server {
     vector<int> Server::openSockets;
 
+
     Server::Server() {
         // Init semaphore for openSockets
         sockets_connections_semaphore = new Semaphore(1);
         feConnectionInitializationSemaphore = new Semaphore(1);
-        feSocketsSemaphore = new Semaphore(1);
+        feAddressesSemaphore = new Semaphore(1);
 
         connectionMonitor = new ConnectionMonitor();
 
-        socketFeList = vector<int>();
+        socketFeList = vector<int>(); // TODO: remove
+        feAddresses = vector<string>();
         this->feAddressBook = FeAddressBook();
         groupManager = new ServerGroupManager(this->feAddressBook);
 
     }
 
     void Server::closeFrontEndConnections() {
-        cout << "Number of front end connections: " << socketFeList.size() << endl;
-        this->feSocketsSemaphore->wait();
-        std::for_each(socketFeList.begin(), socketFeList.end(), close);
-        this->feSocketsSemaphore->post();
-        cout << "Number of front end connections: " << socketFeList.size() << endl;
+        cout << "Number of front end connections: " << feAddresses.size() << endl;
+        this->feAddressesSemaphore->wait();
+        for (auto fe_address : this->feAddresses) {
+            int socketId = getSocketFromAddress(fe_address);
+            close(socketId);
+            cout << "[DEBUG] closed " << fe_address;
+        }
+        this->feAddressesSemaphore->post();
+        cout << "Number of front end connections: " << feAddresses.size() << endl;
     }
 
     void Server::closeServer() {
@@ -55,18 +61,19 @@ namespace server {
      * @param group
      * @return
      */
-    int Server::registerUser(pair<char *, int> clientIdentifier, char *username, char *group) {
+    int Server::registerUser(pair<string, string> clientIdentifier, char *username, char *group) {
         return groupManager->registerUserToGroup(clientIdentifier, username, group);
     }
 
-    int Server::registerUserToServer(Packet *registrationPacket, int frontEndSocket) {
+    int Server::registerUserToServer(Packet *registrationPacket, string feAddress) {
         // Store new crated socket in the vector of existing connections sockets and increment counter for the user
+        int socketId = getSocketFromAddress(feAddress);
         this->sockets_connections_semaphore->wait();
         if (incrementNumberOfConnectionsFromUser(registrationPacket->username) == USER_SESSIONS_LIMIT_REACHED ) { // we can keep this
             Packet *connectionRefusedPacket = new Packet(CONNECTION_REFUSED_PACKET);
             strcpy(connectionRefusedPacket->user_id, registrationPacket->user_id);
             std::cout << "[DEBUG|ERROR] limit sessoes alcanadas pelo user" << std::endl;
-            this->sendPacket(frontEndSocket, connectionRefusedPacket);
+            this->sendPacket(socketId, connectionRefusedPacket);
             this->sockets_connections_semaphore->post();
             return -1;
         }
@@ -74,11 +81,10 @@ namespace server {
 
         std::pair<string, string> clientFrontEndIdentifier = std::pair<string, string>(); // this is the identifier for the client and we need to store this in the groups
         clientFrontEndIdentifier.first.assign(registrationPacket->user_id);
-        clientFrontEndIdentifier.second.assign(registrationPacket->feAddress);
+        clientFrontEndIdentifier.second.assign(feAddress);
 
         return this->registerUser(clientFrontEndIdentifier, registrationPacket->username,
                                             registrationPacket->group);
-
 
     }
 
@@ -117,27 +123,30 @@ namespace server {
         std::cout << "conectado ao FE (" << feIpPort << ") com socket:" << newSocketFE << std::endl;
 
         this->feAddressBook.registryAddressSocket(feIpPort, newSocketFE);
+        this->feAddresses.push_back(feIpPort);
 
         return 0;
     }
 
-    int Server::handleFrontEndsConnections() { //TODO same as in other places, tids mess
+    int Server::handleFrontEndsConnections() {
         std::pair<string, Server *> *args = (std::pair<string, Server *> *) calloc(1, sizeof(std::pair<string, Server *>));
+
         vector<ConnectionKeeper*> connectionKeepers = vector<ConnectionKeeper*>();
         args->second = this;
 
         int i = 0;
-        feSocketsSemaphore->wait();
-        for ( int feSocket : this->socketFeList ) {
+        feAddressesSemaphore->wait();
+        for ( string feAddress : this->feAddresses ) {
+            int socketId = getSocketFromAddress(feAddress);
             this->feConnectionInitializationSemaphore->wait(); // the POST is done inside the new threads created only when the args is no longer necessary
-            args->first = feSocket;
+            args->first.assign(feAddress);
             pthread_create(&(this->tid[i++]), NULL, listenFrontEndCommunication, (void *) args);
-            std::cout << "handleFrontEndsConnections ao FE com socket:" << feSocket << std::endl;
+            std::cout << "handleFrontEndsConnections ao FE com socket:" << feAddress << ", socket:" << socketId << std::endl;
             this->feConnectionInitializationSemaphore->wait();
             pthread_create(&(this->tid[i++]), NULL, monitorConnection, (void *) args);
-            connectionKeepers.push_back(new ConnectionKeeper(feSocket)); // starts the thread that keeps sending keep alives
+            connectionKeepers.push_back(new ConnectionKeeper(socketId)); // starts the thread that keeps sending keep alives
         }
-        feSocketsSemaphore->post();
+        feAddressesSemaphore->post();
 
         this->feConnectionInitializationSemaphore->wait();
         free(args);
@@ -147,30 +156,33 @@ namespace server {
     }
 
     void * Server::monitorConnection(void *args) {
-        std::pair<int, Server *> *args_pair = (std::pair<int, Server *> *) args;
-        int fe_socketfd = (int) args_pair->first;
+        std::pair<string, Server *> *args_pair = (std::pair<string, Server *> *) args;
+        string feAddress((string) args_pair->first);
         Server *_this = (Server *) args_pair->second;
 
-        _this->feConnectionInitializationSemaphore->post();
+        int socketID = _this->getSocketFromAddress(feAddress);
 
-        _this->connectionMonitor->monitor(&fe_socketfd);
-        _this->closeFrontEndConnection(fe_socketfd);
+        _this->feConnectionInitializationSemaphore->post();
+        _this->connectionMonitor->monitor(&socketID);
+        _this->closeFrontEndConnection(feAddress);
         return NULL;
     }
 
     void *Server::listenFrontEndCommunication(void *args) {
 
         // TODO: receive a pair from the args. The first will be the socket and the second one will be the server
-        std::pair<int, Server *> *args_pair = (std::pair<int, Server *> *) args;
-        int fe_socketfd = (int) args_pair->first;
+        std::pair<string, Server *> *args_pair = (std::pair<string, Server *> *) args;
+        string feAddress(args_pair->first);
         Server *_this = (Server *) args_pair->second;
+
+        int feSocket = _this->getSocketFromAddress(feAddress);
 
         _this->feConnectionInitializationSemaphore->post();
 
         bool connectedFrontEnd = true;
         while (connectedFrontEnd) {
             // Listen for an incoming Packet from client
-            Packet *receivedPacket = _this->readPacket(fe_socketfd, &connectedFrontEnd);
+            Packet *receivedPacket = _this->readPacket(feSocket, &connectedFrontEnd);
             if (!connectedFrontEnd) {
                 // Free allocated memory for reading Packet
                 free(receivedPacket);
@@ -186,32 +198,30 @@ namespace server {
                 Packet *pack = new Packet();
                 pack->type = ACK_PACKET;
                 strcpy(pack->user_id, receivedPacket->user_id);
-                _this->sendPacket(fe_socketfd, pack);
-                std::cout << "[DEBUG] mandei ACK para socket: " << fe_socketfd << std::endl;
+                _this->sendPacket(feSocket, pack);
+                std::cout << "[DEBUG] mandei ACK para socket: " << feSocket << std::endl;
                 _this->groupManager->processReceivedPacket(receivedPacket);
             } else if (receivedPacket->isKeepAlive()){
-                _this->connectionMonitor->refresh(fe_socketfd);
+                _this->connectionMonitor->refresh(feSocket);
             } else if (receivedPacket->isJoinMessage()) {
                 std::cout << "[DEBUG] recebi joinMessage" << std::endl;
-                _this->registerUserToServer(receivedPacket, fe_socketfd); // considers the front end connection
+                _this->registerUserToServer(receivedPacket, feAddress); // considers the front end connection
             } else if (receivedPacket->isDisconnect()) {
-                pair<char *, int> connectionId = pair<char *, int>();
-                connectionId.first = (char*)malloc(UUID_SIZE*sizeof(char));
-                strcpy(connectionId.first, receivedPacket->user_id);
-                connectionId.second = fe_socketfd;
-
-                std::cout << "[DEBUG] vou chamar a rotina para o disconnect do client " << receivedPacket->user_id << std::endl;
+                pair<string, string> connectionId = pair<string, string>();
+                connectionId.first.assign(receivedPacket->user_id);
+                connectionId.second.assign(feAddress);
+                std::cout << "[DEBUG] vou chamar a rotina para o disconnect do fe " <<  connectionId.first << "endereco" << feAddress << std::endl;
                 _this->closeClientConnection(connectionId); // considers the front end connection
             }
 
         }
 
-        _this->connectionMonitor->killSocket(fe_socketfd);
+        _this->connectionMonitor->killSocket(feSocket);
         // Close all properties related to client connection
-        _this->closeFrontEndConnection(fe_socketfd);
+        _this->closeFrontEndConnection(feAddress);
 
 
-        cout << "Stopped listening on FE socket " << fe_socketfd << endl;
+        cout << "Stopped listening on FE socket " << feSocket << "address: " << feAddress << endl;
 
         //exit(0);
 
@@ -222,48 +232,51 @@ namespace server {
      * When the FE dies, let's process it and kill all the connections that we had for the users
      * @param socketId
      */
-    void Server::closeFrontEndConnection(int socketId) {
-
+    void Server::closeFrontEndConnection(string feAddress) {
         bool connectionFound = false;
-        feSocketsSemaphore->wait();
-        for (int feConnection : this->socketFeList) {
-            if (feConnection == socketId) {
+        feAddressesSemaphore->wait();
+        for (string currentAddress : this->feAddresses) {
+            if (feAddress.compare(currentAddress) == 0) {
                 connectionFound = true;
                 break;
             }
         }
-        feSocketsSemaphore->post();
+        feAddressesSemaphore->post();
 
         if (!connectionFound) return; // cai fora pq a gente já fechou esse socket
 
-        cout << "[DEBUG] closeFrontEndConnection closing FE " << socketId << endl;
-        pair <char *, int> connectionId = pair<char*, int>();
-        connectionId.first = (char*)malloc(UUID_SIZE*sizeof(char));
-        strcpy(connectionId.first, FE_DISCONNECT);
-        connectionId.second = socketId;
+        cout << "[DEBUG] closeFrontEndConnection closing FE " << feAddress << endl;
+        pair <string, string> connectionId = pair<string, string>();
+        connectionId.first.assign(FE_DISCONNECT);
+        connectionId.second.assign(feAddress);
+
         closeClientConnection(connectionId);
-        if ((close(socketId)) == 0) {
-            std::cout << "\nClosed socket: " << socketId << std::endl;
+        
+        int socketId = getSocketFromAddress(feAddress);
+
+        if ( (close(socketId) ) == 0) {
+            std::cout << "\nClosed socket: " << socketId << ", connection with FE " << feAddress << std::endl;
         } else {
             std::cout << "!!! Fatal error closing socket!!!!" << std::endl;
         }
-        eraseSocketFromFeSocketList(socketId);
+        purgeFeConnection(feAddress);
     }
 
-    void Server::eraseSocketFromFeSocketList(int socketId) {
-        feSocketsSemaphore->wait();
+    void Server::purgeFeConnection(string feAddress) {
+        feAddressesSemaphore->wait();
         int deletion_index = 0;
-        auto begin = socketFeList.begin();
-        for (auto socket : socketFeList) {
-            if ( socket == socketId ) {
-                socketFeList.erase(begin + deletion_index); // will delete the deletion_index's item
+        auto begin = feAddresses.begin();
+        for (auto address : feAddresses) {
+            if (address.compare(feAddress) == 0 ) {
+                feAddresses.erase(begin + deletion_index); // will delete the deletion_index's item
+                feAddressBook.removeServerSocket(feAddress);
             }
             deletion_index += 1;
         }
-        feSocketsSemaphore->post();
+        feAddressesSemaphore->post();
     }
 
-    void Server::closeClientConnection(pair<char *, int> clientConnectionId) {
+    void Server::closeClientConnection(pair<string, string> clientConnectionId) {
         sockets_connections_semaphore->wait();
         groupManager->propagateSocketDisconnectionEvent(clientConnectionId, this->connectionsCount);
         sockets_connections_semaphore->post();
@@ -289,4 +302,14 @@ namespace server {
             return 0;
         }
     }
+
+    int Server::getSocketFromAddress(const string feAddress) {
+        int socketId = feAddressBook.getInternalSocketId(feAddress);
+
+        if (socketId == 0) {
+            cout << "[ERROR] the address provided for the FE does not have any socket" << endl;
+        }
+        return socketId;
+    }
+
 }

--- a/Instant-Messenger/src/server/server.cpp
+++ b/Instant-Messenger/src/server/server.cpp
@@ -27,7 +27,7 @@ namespace server {
 
         socketFeList = vector<int>(); // TODO: remove
         feAddresses = vector<string>();
-        this->feAddressBook = FeAddressBook();
+        this->feAddressBook = new FeAddressBook();
         groupManager = new ServerGroupManager(this->feAddressBook);
 
     }
@@ -122,7 +122,7 @@ namespace server {
 
         std::cout << "conectado ao FE (" << feIpPort << ") com socket:" << newSocketFE << std::endl;
 
-        this->feAddressBook.registryAddressSocket(feIpPort, newSocketFE);
+        this->feAddressBook->registryAddressSocket(feIpPort, newSocketFE);
         this->feAddresses.push_back(feIpPort);
 
         return 0;
@@ -269,7 +269,7 @@ namespace server {
         for (auto address : feAddresses) {
             if (address.compare(feAddress) == 0 ) {
                 feAddresses.erase(begin + deletion_index); // will delete the deletion_index's item
-                feAddressBook.removeServerSocket(feAddress);
+                feAddressBook->removeServerSocket(feAddress);
             }
             deletion_index += 1;
         }
@@ -304,7 +304,7 @@ namespace server {
     }
 
     int Server::getSocketFromAddress(const string feAddress) {
-        int socketId = feAddressBook.getInternalSocketId(feAddress);
+        int socketId = feAddressBook->getInternalSocketId(feAddress);
 
         if (socketId == 0) {
             cout << "[ERROR] the address provided for the FE does not have any socket" << endl;

--- a/Instant-Messenger/src/server/server.cpp
+++ b/Instant-Messenger/src/server/server.cpp
@@ -32,6 +32,7 @@ namespace server {
             // bzero(&(serv_addr.sin_zero), 8);
         }
         socketFeList = vector<int>();
+        this->feAddressBook = FeAddressBook();
 
     }
 
@@ -77,10 +78,9 @@ namespace server {
         }
         this->sockets_connections_semaphore->post();
 
-        std::pair<char *, int> clientFrontEndIdentifier = std::pair<char *, int>(); // this is the identifier for the client and we need to store this in the groups
-        clientFrontEndIdentifier.first = (char*)malloc(UUID_SIZE*sizeof(char));
-        strcpy(clientFrontEndIdentifier.first, registrationPacket->user_id);
-        clientFrontEndIdentifier.second = frontEndSocket;
+        std::pair<string, string> clientFrontEndIdentifier = std::pair<string, string>(); // this is the identifier for the client and we need to store this in the groups
+        clientFrontEndIdentifier.first.assign(registrationPacket->user_id);
+        clientFrontEndIdentifier.second.assign(registrationPacket->feAddress);
 
         return this->registerUser(clientFrontEndIdentifier, registrationPacket->username,
                                             registrationPacket->group);
@@ -117,13 +117,18 @@ namespace server {
         }
 
         socketFeList.push_back(newSocketFE);
-        std::cout << "conectado ao FE com socket:" << newSocketFE << std::endl;
+
+        string feIpPort = feAddress + ":" + to_string(fePort);
+
+        std::cout << "conectado ao FE (" << feIpPort << ") com socket:" << newSocketFE << std::endl;
+
+        this->feAddressBook.registryAddressSocket(feIpPort, newSocketFE);
 
         return 0;
     }
 
     int Server::handleFrontEndsConnections() { //TODO same as in other places, tids mess
-        std::pair<int, Server *> *args = (std::pair<int, Server *> *) calloc(1, sizeof(std::pair<int, Server *>));
+        std::pair<string, Server *> *args = (std::pair<string, Server *> *) calloc(1, sizeof(std::pair<string, Server *>));
         vector<ConnectionKeeper*> connectionKeepers = vector<ConnectionKeeper*>();
         args->second = this;
 

--- a/Instant-Messenger/src/server/server_group_manager.cpp
+++ b/Instant-Messenger/src/server/server_group_manager.cpp
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace servergroupmanager {
 
-    ServerGroupManager::ServerGroupManager(FeAddressBook feAddressBook) : semaphore(1) {
+    ServerGroupManager::ServerGroupManager(FeAddressBook* feAddressBook) : semaphore(1) {
         this->feAddressBook = feAddressBook;
     }
 

--- a/Instant-Messenger/src/server/server_group_manager.cpp
+++ b/Instant-Messenger/src/server/server_group_manager.cpp
@@ -4,10 +4,6 @@ using namespace std;
 
 namespace servergroupmanager {
 
-    ServerGroupManager::ServerGroupManager() : semaphore(1) {
-
-    }
-
     ServerGroupManager::ServerGroupManager(FeAddressBook feAddressBook) : semaphore(1) {
         this->feAddressBook = feAddressBook;
     }
@@ -19,7 +15,7 @@ namespace servergroupmanager {
      * @param groupName
      * @return
      */
-    int ServerGroupManager::registerUserToGroup(pair<string, string> clientIdentifier, string username, string groupName) { //TODO: update to string,string
+    int ServerGroupManager::registerUserToGroup(pair<string, string> clientIdentifier, string username, string groupName) {
 
         // if groupName exists, send the registration to it. If it does not belong to the map of groups, we instantiate a new groupName and forward the information to it
         Group* group = NULL;
@@ -29,7 +25,7 @@ namespace servergroupmanager {
         }
         group =  this->groupMap[groupName];
 
-        return group->registerNewSession(clientIdentifier.first, clientIdentifier.second, username); //TODO: update this to use the string, string
+        return group->registerNewSession(clientIdentifier.first, clientIdentifier.second, username);
     }
 
 
@@ -52,12 +48,12 @@ namespace servergroupmanager {
      * Hey bro, this sockets disconected, it may interest you. Of so, process this event as you want.
      * @param connectionId
      */
-    void ServerGroupManager::propagateSocketDisconnectionEvent(pair<char *, int> connectionId, map<string, int> &numberOfConnectionsByUser) { //TODO: update this to string,string
+    void ServerGroupManager::propagateSocketDisconnectionEvent(pair<string, string> connectionId, map<string, int> &numberOfConnectionsByUser) {
         std::map<basic_string<char>, Group*>::iterator it = this->groupMap.begin();
 
         while ( it != this->groupMap.end() ) { // iterates over the map
             Group* group = it->second;
-            group->handleDisconnectEvent(connectionId.first, connectionId.second, numberOfConnectionsByUser); //TODO: update this to string,string
+            group->handleDisconnectEvent(connectionId.first, connectionId.second, numberOfConnectionsByUser);
             it++;
         }
     }

--- a/Instant-Messenger/src/server/server_group_manager.cpp
+++ b/Instant-Messenger/src/server/server_group_manager.cpp
@@ -8,6 +8,10 @@ namespace servergroupmanager {
 
     }
 
+    ServerGroupManager::ServerGroupManager(FeAddressBook feAddressBook) : semaphore(1) {
+        this->feAddressBook = feAddressBook;
+    }
+
     /**
      * This function will be used to active the registration for the right groupName
      * @param clientIdentifier
@@ -15,17 +19,17 @@ namespace servergroupmanager {
      * @param groupName
      * @return
      */
-    int ServerGroupManager::registerUserToGroup(pair<char *, int> clientIdentifier, string username, string groupName) {
+    int ServerGroupManager::registerUserToGroup(pair<string, string> clientIdentifier, string username, string groupName) { //TODO: update to string,string
 
         // if groupName exists, send the registration to it. If it does not belong to the map of groups, we instantiate a new groupName and forward the information to it
         Group* group = NULL;
         if ( !groupExists(groupName) ) {
-            this->groupMap[groupName] = new Group(groupName);
+            this->groupMap[groupName] = new Group(groupName, this->feAddressBook);
             this->groupMap[groupName]->configureFileSystemManager(this->maxNumberOfMessagesOnHistory);
         }
         group =  this->groupMap[groupName];
 
-        return group->registerNewSession(clientIdentifier.first, clientIdentifier.second, username);
+        return group->registerNewSession(clientIdentifier.first, clientIdentifier.second, username); //TODO: update this to use the string, string
     }
 
 
@@ -48,12 +52,12 @@ namespace servergroupmanager {
      * Hey bro, this sockets disconected, it may interest you. Of so, process this event as you want.
      * @param connectionId
      */
-    void ServerGroupManager::propagateSocketDisconnectionEvent(pair<char *, int> connectionId, map<string, int> &numberOfConnectionsByUser) {
+    void ServerGroupManager::propagateSocketDisconnectionEvent(pair<char *, int> connectionId, map<string, int> &numberOfConnectionsByUser) { //TODO: update this to string,string
         std::map<basic_string<char>, Group*>::iterator it = this->groupMap.begin();
 
         while ( it != this->groupMap.end() ) { // iterates over the map
             Group* group = it->second;
-            group->handleDisconnectEvent(connectionId.first, connectionId.second, numberOfConnectionsByUser);
+            group->handleDisconnectEvent(connectionId.first, connectionId.second, numberOfConnectionsByUser); //TODO: update this to string,string
             it++;
         }
     }

--- a/Instant-Messenger/src/server/server_message_manager.cpp
+++ b/Instant-Messenger/src/server/server_message_manager.cpp
@@ -3,7 +3,7 @@
 
 namespace servermessagemanager {
 
-    ServerMessageManager::ServerMessageManager(FeAddressBook feAddressBook) {
+    ServerMessageManager::ServerMessageManager(FeAddressBook* feAddressBook) {
         this->feAddressBook = feAddressBook;
     }
 
@@ -59,7 +59,7 @@ namespace servermessagemanager {
     }
 
     int ServerMessageManager::getSocketFromAddress(const string &feAddress) {
-        int socketId = feAddressBook.getInternalSocketId(feAddress);
+        int socketId = feAddressBook->getInternalSocketId(feAddress);
 
         if (socketId == 0) {
             cout << "[ERROR] the address provided for the FE does not have any socket" << endl;

--- a/Instant-Messenger/src/server/server_message_manager.cpp
+++ b/Instant-Messenger/src/server/server_message_manager.cpp
@@ -12,7 +12,7 @@ namespace servermessagemanager {
      * @param message
      * @param clientID
      */
-    void ServerMessageManager::sendMessageToSocketId(Message message, string clientID, int feSocket) //TODO: update this to string,string
+    void ServerMessageManager::sendMessageToSocketId(Message message, string clientID, int feSocket)
     {
         Packet* sendingPacket = new Packet(
                 (char*)message.getUser().c_str(),
@@ -22,7 +22,7 @@ namespace servermessagemanager {
                 (char*)clientID.c_str(), // this field is the client's identifier in the FE. aka user_id for some
                MESSAGE_PACKET);
 
-        sendPacket(feSocket, sendingPacket); //TODO: update this to string,string
+        sendPacket(feSocket, sendingPacket);
     }
 
     /**
@@ -30,15 +30,10 @@ namespace servermessagemanager {
      * @param message
      * @param clientID
      */
-    void ServerMessageManager::sendMessageToSocketId(Message message, string clientID, string feAddress) //TODO: update this to string,string
+    void ServerMessageManager::sendMessageToSession(Message message, string clientID, string feAddress)
     {
 
-        int socketId = this->feAddressBook.getInternalSocketId(feAddress);
-
-        if (socketId == 0) {
-            cout << "[ERROR] the address provided for the FE does not have any socket" << endl;
-        }
-
+        int socketId = getSocketFromAddress(feAddress);
 
         Packet* sendingPacket = new Packet(
                 (char*)message.getUser().c_str(),
@@ -48,7 +43,7 @@ namespace servermessagemanager {
                 (char*)clientID.c_str(), // this field is the client's identifier in the FE. aka user_id for some
                 MESSAGE_PACKET);
 
-        sendPacket(socketId, sendingPacket); //TODO: update this to string,string
+        sendPacket(socketId, sendingPacket);
     }
 
     /**
@@ -59,13 +54,17 @@ namespace servermessagemanager {
      */
     void ServerMessageManager::sendMessageToAddress(Message message, string clientId, string feAddress) {
 
-        int socketId = this->feAddressBook.getInternalSocketId(feAddress);
+        int socketId = getSocketFromAddress(feAddress);
+        sendMessageToSocketId(message, clientId, socketId);
+    }
+
+    int ServerMessageManager::getSocketFromAddress(const string &feAddress) {
+        int socketId = feAddressBook.getInternalSocketId(feAddress);
 
         if (socketId == 0) {
             cout << "[ERROR] the address provided for the FE does not have any socket" << endl;
         }
-
-        sendMessageToSocketId(message, clientId, socketId)
+        return socketId;
     }
 
 
@@ -74,9 +73,10 @@ namespace servermessagemanager {
      * @param packet
      * @param clientIdentifier
      */
-    void ServerMessageManager::sendPacketToSocketId(Packet* packet, int socket)
+    void ServerMessageManager::sendPacketToSocketId(Packet* packet, string feAddress)
     {
-        sendPacket(socket, packet); //TODO: update this to string,string
+        int socketID = getSocketFromAddress(feAddress);
+        sendPacket(socketID, packet);
     }
 
     /**
@@ -88,10 +88,10 @@ namespace servermessagemanager {
      * @param message
      * @param connectionIds
      */
-    void ServerMessageManager::broadcastMessageToUsers(Message message, vector< pair<char *, int> > connectionIds) //TODO: update this to string,string
+    void ServerMessageManager::broadcastMessageToUsers(Message message, vector< pair<string, string> > connectionIds)
     {
         for ( auto clientConnection : connectionIds) {
-            sendMessageToSocketId(message, clientConnection.first, clientConnection.second); //TODO: update this to string,string
+            sendMessageToSession(message, clientConnection.first, clientConnection.second);
         }
     }
 }

--- a/Instant-Messenger/src/server/server_message_manager.cpp
+++ b/Instant-Messenger/src/server/server_message_manager.cpp
@@ -3,24 +3,72 @@
 
 namespace servermessagemanager {
 
+    ServerMessageManager::ServerMessageManager(FeAddressBook feAddressBook) {
+        this->feAddressBook = feAddressBook;
+    }
+
     /**
      * This method is responsible for building a package from a message and send it thought the socket :)
      * @param message
      * @param clientID
      */
-    void ServerMessageManager::sendMessageToSocketId(Message message, char *clientID, int feSocket)
+    void ServerMessageManager::sendMessageToSocketId(Message message, string clientID, int feSocket) //TODO: update this to string,string
     {
         Packet* sendingPacket = new Packet(
                 (char*)message.getUser().c_str(),
                 (char*)message.getGroup().c_str(),
                 (char*)message.getText().c_str(),
                 message.getTime(),
-                clientID, // this field is the client's identifier in the FE. aka user_id for some
+                (char*)clientID.c_str(), // this field is the client's identifier in the FE. aka user_id for some
                MESSAGE_PACKET);
 
-        sendPacket(feSocket, sendingPacket);
+        sendPacket(feSocket, sendingPacket); //TODO: update this to string,string
     }
-    
+
+    /**
+     * This method is responsible for building a package from a message and send it thought the socket :)
+     * @param message
+     * @param clientID
+     */
+    void ServerMessageManager::sendMessageToSocketId(Message message, string clientID, string feAddress) //TODO: update this to string,string
+    {
+
+        int socketId = this->feAddressBook.getInternalSocketId(feAddress);
+
+        if (socketId == 0) {
+            cout << "[ERROR] the address provided for the FE does not have any socket" << endl;
+        }
+
+
+        Packet* sendingPacket = new Packet(
+                (char*)message.getUser().c_str(),
+                (char*)message.getGroup().c_str(),
+                (char*)message.getText().c_str(),
+                message.getTime(),
+                (char*)clientID.c_str(), // this field is the client's identifier in the FE. aka user_id for some
+                MESSAGE_PACKET);
+
+        sendPacket(socketId, sendingPacket); //TODO: update this to string,string
+    }
+
+    /**
+     * Makes the search for socket id in the feAddressBook and sends the message to the right socket
+     * @param message
+     * @param clientId
+     * @param feAddress
+     */
+    void ServerMessageManager::sendMessageToAddress(Message message, string clientId, string feAddress) {
+
+        int socketId = this->feAddressBook.getInternalSocketId(feAddress);
+
+        if (socketId == 0) {
+            cout << "[ERROR] the address provided for the FE does not have any socket" << endl;
+        }
+
+        sendMessageToSocketId(message, clientId, socketId)
+    }
+
+
     /**
      * This method is responsiblefor for sending a Packet to a socket :)
      * @param packet
@@ -28,7 +76,7 @@ namespace servermessagemanager {
      */
     void ServerMessageManager::sendPacketToSocketId(Packet* packet, int socket)
     {
-        sendPacket(socket, packet);
+        sendPacket(socket, packet); //TODO: update this to string,string
     }
 
     /**
@@ -40,10 +88,10 @@ namespace servermessagemanager {
      * @param message
      * @param connectionIds
      */
-    void ServerMessageManager::broadcastMessageToUsers(Message message, vector< pair<char *, int> > connectionIds)
+    void ServerMessageManager::broadcastMessageToUsers(Message message, vector< pair<char *, int> > connectionIds) //TODO: update this to string,string
     {
         for ( auto clientConnection : connectionIds) {
-            sendMessageToSocketId(message, clientConnection.first, clientConnection.second);
+            sendMessageToSocketId(message, clientConnection.first, clientConnection.second); //TODO: update this to string,string
         }
     }
 }

--- a/Instant-Messenger/src/util/user.cpp
+++ b/Instant-Messenger/src/util/user.cpp
@@ -2,7 +2,6 @@
 #include "../../include/util/definitions.hpp"
 #include <iostream>
 #include <algorithm>
-#include <string.h>
 
 namespace user {
     User::User(string username) : semaphore(1) {
@@ -12,7 +11,7 @@ namespace user {
 
     void User::initSessionList() {
         this->semaphore.wait();
-        this->clientIdentifiers = std::vector< pair <char *, int> >(); // pair (clientID, feSocket)
+        this->clientIdentifiers = std::vector< pair <string, string> >(); // pair (clientID, feSocket)
         this->semaphore.post();
     }
 
@@ -24,7 +23,7 @@ namespace user {
      * Returns the identifiers for all sessions that this user has vector of pairs (clientID, feSocket)
      * @return
      */
-    std::vector<pair<char *, int>> User::getActiveConnections() {
+    std::vector<pair<string, string>> User::getActiveConnections() {
         return this->clientIdentifiers;
     }
 
@@ -35,16 +34,15 @@ namespace user {
      * @param clientID
      * @return negative if error
      */
-    int User::registerSession(char *clientID, int feSocket) {
+    int User::registerSession(string clientID, string feAddress) { // TODO: update to use string,string
 
-        pair<char *, int> clientID_feSocket = pair<char *, int>();
-        clientID_feSocket.first = (char*)malloc(UUID_SIZE*sizeof(char));
-        strcpy(clientID_feSocket.first, clientID);
-        clientID_feSocket.second = feSocket;
+        pair<string, string> clientID_feSocket = pair<string, string>();
+        clientID_feSocket.first.assign(clientID); //TODO: debug to confirm
+        clientID_feSocket.second.assign(feAddress);
 
         this->semaphore.wait();
         if (this->clientIdentifiers.size() < MAX_NUMBER_OF_SIMULTANEOUS_CONNECTIONS ) {
-            this->clientIdentifiers.push_back(clientID_feSocket);
+            this->clientIdentifiers.push_back(clientID_feSocket); // TODO: update this shit
             this->semaphore.post();
             return 0;
         } else {
@@ -59,15 +57,15 @@ namespace user {
      * client's identifier is maintained by a pair (clientID, feSocket). We need to use this pair
      * to delete the existing session accordingly
      *
-     * @param feSocket
      * @param clientID
+     * @param feAddress
      */
-    void User::releaseSession(char *clientID, int feSocket) {
+    void User::releaseSession(string clientID, string feAddress) {
         this->semaphore.wait();
         int deletion_index = 0;
         auto begin = this->clientIdentifiers.begin();
         for (auto userSession : this->clientIdentifiers) {
-            if ( strcmp(userSession.first, clientID) == 0 && userSession.second == feSocket) {
+            if ( userSession.first.compare(clientID) == 0 && userSession.first.compare(feAddress) ) {
                 this->clientIdentifiers.erase(begin + deletion_index); // will delete the deletion_index's item
             }
             deletion_index += 1;
@@ -82,7 +80,5 @@ namespace user {
         for (auto identification : this->clientIdentifiers) {
             cout << "printsockt::Client Dispositive Identifier: " << identification.first << " FE socket: " << identification.second << endl;
         }
-
-
     }
 } // namespace user;

--- a/Instant-Messenger/src/util/user.cpp
+++ b/Instant-Messenger/src/util/user.cpp
@@ -34,7 +34,7 @@ namespace user {
      * @param clientID
      * @return negative if error
      */
-    int User::registerSession(string clientID, string feAddress) { // TODO: update to use string,string
+    int User::registerSession(string clientID, string feAddress) {
 
         pair<string, string> clientID_feSocket = pair<string, string>();
         clientID_feSocket.first.assign(clientID); //TODO: debug to confirm
@@ -42,7 +42,7 @@ namespace user {
 
         this->semaphore.wait();
         if (this->clientIdentifiers.size() < MAX_NUMBER_OF_SIMULTANEOUS_CONNECTIONS ) {
-            this->clientIdentifiers.push_back(clientID_feSocket); // TODO: update this shit
+            this->clientIdentifiers.push_back(clientID_feSocket);
             this->semaphore.post();
             return 0;
         } else {


### PR DESCRIPTION
Esse pull request arruma a questão de perdermos o significado dos sockets do servidor para o os FEs no momento que o primário cai e um secundário deve assumir.

Antes as sessões dos clientes tinham o identificador único de (feSocket, clientIdentification). Mas como o socket id é dinâmico e dependente da ordem que o processo requisita, o socketId de um FE não é necessariamente o mesmo para o backup quando ele assumir. Assim utilizamos um mapeamento do endereço ip:porta para o socket. Assim, tudo se baseia nesse endereço, juntamente com o id do client do usuário.

